### PR TITLE
Check for definedness of php_register_mods_ini var

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,7 +57,7 @@
 - name: Fix php module ini-files and remove DEFAULT section
   tags: php
   with_items: php_register_mods_ini.results
-  when: item.stat.exists
+  when: php_register_mods_ini.results is defined and item.stat.exists
   shell:
     chdir={{ php_fact_mods_dir }}
     crudini --set {{ item.item.name }}.ini {{ item.item.name }};


### PR DESCRIPTION
The defaults vars file sets the `php_modules_conf` var to an empty list,
but a role task assumes that the var will be defined, by referencing
the skipped registered var that includes results captured via `with_items`.
The solution is to check for definedness and skip the dependent task if
the var isn't defined.
